### PR TITLE
remove generate gc bias process output declaration

### DIFF
--- a/panelGC.nf
+++ b/panelGC.nf
@@ -219,9 +219,6 @@ process generate_gc_bias {
     val draw_trend
     val show_sample_names
 
-    output:
-    path "${out_dir}/gc_bias_curves.png"
-
     script:
     """
     panelGC_main.R --probe_bed_file $probe_bed --bam_coverage_directory $intersected_coverage_dir \


### PR DESCRIPTION
This PR fixes a bug where Nextflow workflow is expecting an output file with a wrong name in "generate_gc_bias" process. Process "generate_gc_bias" doesn't output a file named "gc_bias_curves.png" anymore.

As this process is the final process of the pipeline we opted to remove any output channel altogether for simplicity.