### PR TITLE
Different lines for binary sample labels in `gc_bias_profile.png`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM rocker/r-ver:4.3
 LABEL base_image="rocker/r-ver:4.3"
 LABEL version="1"
 LABEL software="panelGC"
-LABEL software.version="1.0.2"
+LABEL software.version="1.0.3"
 LABEL about.summary="An open source tool for quantifying and monitoring GC bias in sequencing panels"
 LABEL about.home="https://github.com/easygsea/panelGC"
 LABEL about.license="SPDX:GPL-3.0"
@@ -23,14 +23,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # R packages
 RUN install2.r --error BiocManager argparser tidyverse
 RUN Rscript -e 'requireNamespace("BiocManager"); BiocManager::install("GenomicRanges"); BiocManager::install("rtracklayer")'
+
 # Install Nextflow
-ENV NEXTFLOW_VERSION=23.04.0
-RUN curl -s https://get.nextflow.io | bash && \
-    mv nextflow /usr/local/bin/ && \
+ENV NEXTFLOW_VERSION=24.10.0
+RUN curl -sL https://github.com/nextflow-io/nextflow/releases/download/v${NEXTFLOW_VERSION}/nextflow \
+    -o /usr/local/bin/nextflow && \
     chmod 755 /usr/local/bin/nextflow
 
 # Download and install panelGC from GitHub Releases
-ENV PANELGC_VERSION=1.0.2
+ENV PANELGC_VERSION=1.0.3
 RUN curl -sL https://github.com/easygsea/panelGC/archive/refs/tags/v${PANELGC_VERSION}.tar.gz | tar xz && \
     mv panelGC-${PANELGC_VERSION} /opt/panelGC && \
     chmod -R 755 /opt/panelGC

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ singularity exec \
 ```
 Replace the paths with your actual mounted data directories and file paths. See [Singularity documentation](https://docs.sylabs.io/guides/2.5/user-guide/bind_paths_and_mounts.html) for more information on binding paths and mounts. 
 
-**Note:** `singularity exec` and `nextflow` provide additional options to help optimizeity the deployment of panelGC for your specific use. For more details, please refer to the official guides: [singularity exec](https://docs.sylabs.io/guides/latest/user-guide/cli/singularity_exec.html) and [nextflow CLI reference](https://www.nextflow.io/docs/latest/reference/cli.html#options).
+**Note:** `singularity exec` and `nextflow` provide additional options to help optimize the deployment of panelGC for your specific use. For more details, please refer to the official guides: [singularity exec](https://docs.sylabs.io/guides/latest/user-guide/cli/singularity_exec.html) and [nextflow CLI reference](https://www.nextflow.io/docs/latest/reference/cli.html#options).
 
 ### Parameters
 - --bam_directory_path: Path to the directory containing alignment BAM files. Indices are preferred but not mandatory. Symlinks to the BAM and index files are valid.

--- a/README.md
+++ b/README.md
@@ -45,12 +45,15 @@ singularity exec \
 ```
 Replace the paths with your actual mounted data directories and file paths. See [Singularity documentation](https://docs.sylabs.io/guides/2.5/user-guide/bind_paths_and_mounts.html) for more information on binding paths and mounts. 
 
-**Note:** `singularity exec` and `nextflow` provide additional options to help optimize the deployment of panelGC for your specific use. For more details, please refer to the official guides: [singularity exec](https://docs.sylabs.io/guides/latest/user-guide/cli/singularity_exec.html) and [nextflow CLI reference](https://www.nextflow.io/docs/latest/reference/cli.html#options).
+**Note:** `singularity exec` and `nextflow` provide additional options to help optimizeity the deployment of panelGC for your specific use. For more details, please refer to the official guides: [singularity exec](https://docs.sylabs.io/guides/latest/user-guide/cli/singularity_exec.html) and [nextflow CLI reference](https://www.nextflow.io/docs/latest/reference/cli.html#options).
 
 ### Parameters
 - --bam_directory_path: Path to the directory containing alignment BAM files. Indices are preferred but not mandatory. Symlinks to the BAM and index files are valid.
 - --bed_file_path: Path to the genomic bins (or probes) BED file.
 - --fasta_file_path: Path to the genome FASTA file.
+- --sample_labels_csv_path: Path to a CSV file containing sample labels, optional. SSupplying this file allows you to differentiate line types for different labels in the `gc_bias_profile.png` output. The file should have two columns:
+  - sample: Sample names matching the BAM file names.
+  - \<label>: A column for your labels with "true" or "false" values.
 - --out_dir: Path to the output directory.
 - --at_anchor: GC percentile anchor for detecting AT bias. Should be > 0 and < 50. Default: 25
 - --gc_anchor: GC percentile anchor for detecting GC bias. Should be > 50 and < 100. Default: 75
@@ -73,7 +76,7 @@ Records LOESS depth per GC percentile per sample.
 2. gc_bias_loess_classification.tsv:
 Records b<sub>25</sub>, b<sub>75</sub> and b<sub>75/25</sub> scores, and bias classification per sample.
 3. gc_bias_profile.png:
-The GC bias profile plot.
+The GC bias profile plot. Use the `--sample_labels_csv_path` argument to assign labels and differentiate line types for samples.
 4. gc_bias_trend.png (optional):
 The trend visualization of bias scores. Turned off by default.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Replace the paths with your actual mounted data directories and file paths. See 
 - --bam_directory_path: Path to the directory containing alignment BAM files. Indices are preferred but not mandatory. Symlinks to the BAM and index files are valid.
 - --bed_file_path: Path to the genomic bins (or probes) BED file.
 - --fasta_file_path: Path to the genome FASTA file.
-- --sample_labels_csv_path: Path to a CSV file containing sample labels, optional. SSupplying this file allows you to differentiate line types for different labels in the `gc_bias_profile.png` output. The file should have two columns:
+- --sample_labels_csv_path: Path to a CSV file containing sample labels, optional. Supplying this file allows you to differentiate line types for different labels in the `gc_bias_profile.png` output. The file should have two columns:
   - sample: Sample names matching the BAM file names.
   - \<label>: A column for your labels with "true" or "false" values.
 - --out_dir: Path to the output directory.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Replace the paths with your actual mounted data directories and file paths. See 
 - --fasta_file_path: Path to the genome FASTA file.
 - --sample_labels_csv_path: Path to a CSV file containing sample labels, optional. Supplying this file allows you to differentiate line types for different labels in the `gc_bias_profile.png` output. The file should have two columns:
   - sample: Sample names matching the BAM file names.
-  - \<label>: A column for your labels with "true" or "false" values.
+  - \<label>: A column for your labels with "True" or "False" values.
 - --out_dir: Path to the output directory.
 - --at_anchor: GC percentile anchor for detecting AT bias. Should be > 0 and < 50. Default: 25
 - --gc_anchor: GC percentile anchor for detecting GC bias. Should be > 50 and < 100. Default: 75

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ amd64, arm64v8, ppc64le, s390x ([more info](https://github.com/docker-library/of
 - Singularity (tested with 2.5.1)
 
 Containerized dependencies (no installation required):
-Nextflow 24.10.2
+Nextflow 24.10.0
 bedtools 2.30.0
 r-base 4.3.2 argparser 0.7.1 BiocManager 1.30.22 GenomicRanges 1.54.1 rtracklayer 1.62.0 tidyverse 2.0.0
 

--- a/demo_data/README.md
+++ b/demo_data/README.md
@@ -24,6 +24,7 @@ demo_data
 ├── demo_params.json
 ├── demo_probes.bed
 ├── hg19.fa
+├── sample_types.csv
 ├── simulated_at_bias_high.bam
 ├── simulated_at_bias_high.bam.bai
 ├── simulated_at_bias_medium.bam
@@ -61,6 +62,7 @@ singularity exec -B $(pwd):/workspace /path/to/panelgc_latest.sif \
   --bam_directory_path /workspace/demo_data \
   --bed_file_path /workspace/demo_data/demo_probes.bed \
   --fasta_file_path /workspace/demo_data/hg19.fa \
+  --sample_labels_csv_path /workspace/demo_data/sample_types.csv \
   --out_dir /workspace/demo_output \
   --draw_trend
 ```


### PR DESCRIPTION
This PR introduces:
- `--sample_labels_csv_path` argument to assign labels and differentiate line types for samples in `gc_bias_profile.png` output.